### PR TITLE
Update docker compose command on readme

### DIFF
--- a/02-digitall-mariadb/README.md
+++ b/02-digitall-mariadb/README.md
@@ -19,7 +19,7 @@ To get started, execute the following commands:
 cd ~
 git clone https://github.com/Jahia/provisioning-tutorials.git
 cd provisioning-tutorials/02-digitall-mariadb
-docker-compose up --renew-anon
+docker-compose up --renew-anon-volumes
 ```
 
 You will first see the MariaDB starting up, Jahia will then create the necessary tables and continue with its startup. 

--- a/02-digitall-mariadb/README.md
+++ b/02-digitall-mariadb/README.md
@@ -35,7 +35,7 @@ In this tutorial we switched from `docker run` to `docker-compose`, facilitating
 Two elements are worth pointing in this example:
 
 * The containers are not named and are not using volumes
-* Docker-compose is executed with `--renew-anon`, making sure to start from scratch everytime.
+* Docker-compose is executed with `--renew-anon-volumes`, making sure to start from scratch everytime.
 
 Both elements make sure we're starting from scratch everytime the environment is spun up. You might want to modify this behavior depending on your use case.
 

--- a/03-augmented-search/README.md
+++ b/03-augmented-search/README.md
@@ -17,7 +17,7 @@ To get started, execute the following commands:
 cd ~
 git clone https://github.com/Jahia/provisioning-tutorials.git
 cd provisioning-tutorials/03-augmented-search
-docker-compose up --renew-anon
+docker-compose up --renew-anon-volumes
 ```
 
 While the elasticsearch cluster is starting, you will first see the MariaDB container booting up and Jahia creating the necessary tables and continue with its startup. 

--- a/04-jexperience/README.md
+++ b/04-jexperience/README.md
@@ -33,7 +33,7 @@ You might have noticed that we're introducing another layer of flexibility with 
 
 We can now start the environment:
 ```bash
-docker-compose up --renew-anon
+docker-compose up --renew-anon-volumes
 ```
 
 ## After startup


### PR DESCRIPTION
## Description

On tutorials 02, 03 and 04, in the readme, the command given for docker compose was not working.
I added the `-volumes` parameter on the code

## Tests
No tests required

