### PR TITLE
Update environment variable to use DB_VENDOR

### DIFF
--- a/03-augmented-search/docker-compose.yml
+++ b/03-augmented-search/docker-compose.yml
@@ -39,7 +39,7 @@ services:
         limits:
           memory: 4gb
     environment:
-      DBMS_TYPE: mariadb
+      DB_VENDOR: mariadb
       DB_HOST: mariadb
       DB_NAME: jahia
       DB_USER: jahia

--- a/04-jexperience/docker-compose.yml
+++ b/04-jexperience/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       stack:
         ipv4_address: 172.16.1.30
     environment:
-      DBMS_TYPE: mariadb
+      DB_VENDOR: mariadb
       DB_HOST: mariadb
       DB_NAME: jahia
       DB_USER: jahia


### PR DESCRIPTION
As mentioned in #14, there was a legacy environment variable still present in the provisioning tutorials.